### PR TITLE
Update Dockerfile for using algolisearch 3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-alpine
 
-RUN pip install algoliasearch
+RUN pip install algoliasearch==3.0.0
 
 ADD main.py /main.py
 


### PR DESCRIPTION
Due to a major update in AlgoliaSearch, it is necessary to lock the library version of algolisearch.